### PR TITLE
Files opened by "Copy to" on iOS are not re-openable

### DIFF
--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -197,6 +197,9 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
                 url.stopAccessingSecurityScopedResource()
             }
         }
+        if !securityScope {
+            logDebug("Warning: startAccessingSecurityScopedResource is false for \(url)")
+        }
         let bookmark = try url.bookmarkData()
         let tempFile = try _copyToTempDirectory(url: url)
         return _fileInfoResult(tempFile: tempFile, originalURL: url, bookmark: bookmark)

--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -14,8 +14,7 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
     private var _filePickerResult: FlutterResult?
     private var _filePickerPath: String?
     private var isInitialized = false
-    private var _initOpenUrl: URL? = nil
-    private var _initOpenUrlIsPersistable: Bool? = nil
+    private var _initOpen: (url: URL, persistable: Bool)?
     private var _eventSink: FlutterEventSink? = nil
     private var _eventQueue: [[String: String]] = []
 
@@ -56,12 +55,9 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
             switch call.method {
             case "init":
                 isInitialized = true
-                if let openUrl = _initOpenUrl {
-                    // It is an error for _initOpenUrl to be present but
-                    // _initOpenUrlIsPersistable to be nil
-                    _handleUrl(url: openUrl, persistable: _initOpenUrlIsPersistable!)
-                    _initOpenUrl = nil
-                    _initOpenUrlIsPersistable = nil
+                if let (openUrl, persistable) = _initOpen {
+                    _handleUrl(url: openUrl, persistable: persistable)
+                    _initOpen = nil
                 }
                 result(true)
             case "openFilePicker":
@@ -306,8 +302,7 @@ extension SwiftFilePickerWritablePlugin: FlutterApplicationLifeCycleDelegate {
 //            return false
 //        }
         if (!isInitialized) {
-            _initOpenUrl = url
-            _initOpenUrlIsPersistable = persistable
+            _initOpen = (url, persistable)
             return true
         }
         _handleUrl(url: url, persistable: persistable)

--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -101,11 +101,16 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
         var isStale: Bool = false
         let url = try URL(resolvingBookmarkData: bookmark, bookmarkDataIsStale: &isStale)
         logDebug("url: \(url) / isStale: \(isStale)");
-        if !url.startAccessingSecurityScopedResource() {
-            throw FilePickerError.readError(message: "Unable to start accessing security scope resource.")
+        let securityScope = url.startAccessingSecurityScopedResource()
+        defer {
+            if securityScope {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+        if !securityScope {
+            logDebug("Warning: startAccessingSecurityScopedResource is false for \(url).")
         }
         let copiedFile = try _copyToTempDirectory(url: url)
-        url.stopAccessingSecurityScopedResource()
         result(_fileInfoResult(tempFile: copiedFile, originalURL: url, bookmark: bookmark))
     }
     

--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -132,7 +132,7 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
         
         let destAccess = destination.startAccessingSecurityScopedResource()
         if !destAccess {
-            logDebug("Warning: Unable to access original url \(destination) (destination) \(skipDestinationStartAccess)")
+            logDebug("Warning: startAccessingSecurityScopedResource is false for \(destination) (destination); skipDestinationStartAccess=\(skipDestinationStartAccess)")
 //            throw FilePickerError.invalidArguments(message: "Unable to access original url \(destination)")
         }
         let sourceAccess = sourceFile.startAccessingSecurityScopedResource()

--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -313,12 +313,18 @@ extension SwiftFilePickerWritablePlugin: FlutterApplicationLifeCycleDelegate {
         do {
             if (url.isFileURL) {
                 _channel.invokeMethod("openFile", arguments: try _prepareUrlForReading(url: url, persistable: persistable)) { result in
-                    if !persistable && self._isInboxFile(url) {
+                    guard !persistable else {
+                        // Persistable files don't need cleanup
+                        return
+                    }
+                    if self._isInboxFile(url) {
                         do {
                             try FileManager.default.removeItem(at: url)
                         } catch let error {
                             self.logError("Failed to delete inbox file \(url); error: \(error)")
                         }
+                    } else {
+                        self.logError("Unexpected non-persistable file \(url)")
                     }
                 }
             } else {

--- a/lib/src/file_picker_writable.dart
+++ b/lib/src/file_picker_writable.dart
@@ -39,11 +39,16 @@ class FileInfo {
   final File file;
 
   /// Identifier which can be used for reading at a later time, or used for
-  /// writing back data. See [persistable] to see whether access can persist
-  /// beyond the current process lifetime.
+  /// writing back data. See [persistable] for details on the valid lifetime of
+  /// the identifier.
   final String identifier;
 
-  /// Indicates whether [identifier] is persistable across app relaunches
+  /// Indicates whether [identifier] is persistable. When true, it is safe to
+  /// retain this identifier for access at any later time.
+  ///
+  /// When false, you cannot assume that access will be granted in the
+  /// future. In particular, for files received from outside the app, the
+  /// identifier may only be valid until the [FileInfoHandler] returns.
   final bool persistable;
 
   /// Platform dependent URI.


### PR DESCRIPTION
On iOS, files can be opened from other apps in two ways:

- "Open in _MyApp_"
  - Received in `application(_:open:options:)` as an "open in place" security-scoped resource
  - `options` map contains `UIApplicationOpenURLOptionsOpenInPlaceKey: true`
- "Copy to _MyApp_"
  - Received in `application(_:open:options:)` as a regular (non-security-scoped) file URI
  - File is already copied to app container, so can always be persistently accessed
  - `options` map contains `UIApplicationOpenURLOptionsOpenInPlaceKey: false` in my observation (could hypothetically have `nil` or the key might be absent)

Previously, I thought that with correct setup (proper keys in Info.plist), all apps would be able to "Open In", but it turns out that some, in particular Google Drive, can never "Open In" but only offer "Copy To", regardless of the target application and its capabilities.

file_picker_writable currently handles _receiving_ "Copy To" files OK: it ignores the failure to obtain a security scope in `_prepareUrlForReading`:
https://github.com/hpoul/file_picker_writable/blob/72470d06f366039c568cd216fb5ccc6608cb9326/ios/Classes/SwiftFilePickerWritablePlugin.swift#L188-L198

But when trying to _reopen_ a bookmark obtained from such a file, it fails due to strict checking in `readFile`:
https://github.com/hpoul/file_picker_writable/blob/72470d06f366039c568cd216fb5ccc6608cb9326/ios/Classes/SwiftFilePickerWritablePlugin.swift#L104-L106