### PR TITLE
Handle unhandled exceptions reading file on Android

### DIFF
--- a/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritableImpl.kt
+++ b/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritableImpl.kt
@@ -329,7 +329,11 @@ class FilePickerWritableImpl(
 //    }
     plugin.launch {
       if (isInitialized) {
-        handleUri(data)
+        try {
+          handleUri(data)
+        } catch (e: Exception) {
+          plugin.logDebug("Error trying to handle intent data $data: $e")
+        }
       } else {
         initOpenUrl = data
       }


### PR DESCRIPTION
Proposed solution to #6

I found exceptions on these paths were not handled. My method was to artificially throw a `RuntimeException` in `copyContentUriAndReturnFileInfo` and see what operations caused a crash.