### PR TITLE
Await result in readFile

### DIFF
--- a/lib/src/file_picker_writable.dart
+++ b/lib/src/file_picker_writable.dart
@@ -260,7 +260,7 @@ class FilePickerWritable {
     // ignore: deprecated_member_use_from_same_package
     final file = fileInfo.file;
     try {
-      return reader(fileInfo, file);
+      return await reader(fileInfo, file);
     } catch (e, stackTrace) {
       _logger.warning('Error while calling reader method.', e, stackTrace);
       rethrow;


### PR DESCRIPTION
I updated to the latest API changes and found that the `FileReader` is not awaited in the `readFile` method, so in my application the file was always deleted before it could be read.

(By the way you were right, the changes were not as hard to deal with as I thought they would be.)