### PR TITLE
Remove deprecated FileInfo.file and related code

### DIFF
--- a/lib/src/event_handling.dart
+++ b/lib/src/event_handling.dart
@@ -122,7 +122,6 @@ class FilePickerEventOpen extends FilePickerEvent {
 
   @override
   Future<bool> dispatch(FilePickerEventHandler handler) async {
-    // ignore: deprecated_member_use_from_same_package
     if (await handler.handleFileOpen(_fileInfo, _file)) {
       return true;
     }
@@ -138,7 +137,6 @@ class FilePickerEventOpen extends FilePickerEvent {
   @override
   Future<void> dispose() async {
     if (!noCleanupDeprecatedFileInfo) {
-      // ignore: deprecated_member_use_from_same_package
       await _file.delete();
     }
   }

--- a/lib/src/event_handling.dart
+++ b/lib/src/event_handling.dart
@@ -110,9 +110,10 @@ class FilePickerEventLambda extends FilePickerEvent {
 }
 
 class FilePickerEventOpen extends FilePickerEvent {
-  FilePickerEventOpen(this._fileInfo);
+  FilePickerEventOpen(this._fileInfo, this._file);
 
   final FileInfo _fileInfo;
+  final File _file;
 
   bool noCleanupDeprecatedFileInfo = false;
 
@@ -122,7 +123,7 @@ class FilePickerEventOpen extends FilePickerEvent {
   @override
   Future<bool> dispatch(FilePickerEventHandler handler) async {
     // ignore: deprecated_member_use_from_same_package
-    if (await handler.handleFileOpen(_fileInfo, _fileInfo.file)) {
+    if (await handler.handleFileOpen(_fileInfo, _file)) {
       return true;
     }
     // as a fallback invoke deprecated `handleFileInfo`.
@@ -138,7 +139,7 @@ class FilePickerEventOpen extends FilePickerEvent {
   Future<void> dispose() async {
     if (!noCleanupDeprecatedFileInfo) {
       // ignore: deprecated_member_use_from_same_package
-      await _fileInfo.file.delete();
+      await _file.delete();
     }
   }
 }

--- a/lib/src/file_picker_writable.dart
+++ b/lib/src/file_picker_writable.dart
@@ -98,7 +98,7 @@ class FilePickerWritable {
           final result =
               (call.arguments as Map<dynamic, dynamic>).cast<String, String>();
           final fileInfo = _resultToFileInfo(result);
-          final file = File(result['path']!);
+          final file = _resultToFile(result);
           await _filePickerState._fireFileOpenHandlers(fileInfo, file);
           return true;
         } else if (call.method == 'handleUri') {
@@ -180,7 +180,7 @@ class FilePickerWritable {
       return null;
     }
     final fileInfo = _resultToFileInfo(result);
-    final file = File(result['path']!);
+    final file = _resultToFile(result);
     try {
       return await reader(fileInfo, file);
     } finally {
@@ -226,7 +226,7 @@ class FilePickerWritable {
       throw StateError('Error while reading file with identifier $identifier');
     }
     final fileInfo = _resultToFileInfo(result);
-    final file = File(result['path']!);
+    final file = _resultToFile(result);
     try {
       return await reader(fileInfo, file);
     } catch (e, stackTrace) {
@@ -280,6 +280,10 @@ class FilePickerWritable {
       uri: result['uri']!,
       fileName: result['fileName'],
     );
+  }
+
+  File _resultToFile(Map<String, String> result) {
+    return File(result['path']!);
   }
 
   Future<T> _createFileInNewTempDirectory<T>(


### PR DESCRIPTION
As I mentioned at https://github.com/hpoul/file_picker_writable/issues/16#issuecomment-812502955 I would like to be able to use `FileInfo` to describe files that exist but that we haven't tried to read the contents of yet. Currently the requirement of a non-null `File` member in `FileInfo` prevents that.