### PR TITLE
Implement disposeIdentifier method

### DIFF
--- a/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritableImpl.kt
+++ b/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritableImpl.kt
@@ -313,6 +313,14 @@ class FilePickerWritableImpl(
     copyContentUriAndReturn(result, fileUri)
   }
 
+  fun disposeIdentifier(identifier: String) {
+    val activity = requireActivity()
+    val contentResolver = activity.applicationContext.contentResolver
+    val takeFlags: Int = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+      Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+    contentResolver.releasePersistableUriPermission(Uri.parse(identifier), takeFlags)
+  }
+
   private fun requireActivity() = (plugin.activity
     ?: throw FilePickerException("Illegal state, expected activity to be there."))
 

--- a/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritablePlugin.kt
+++ b/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritablePlugin.kt
@@ -128,6 +128,12 @@ class FilePickerWritablePlugin : FlutterPlugin, MethodCallHandler,
               ?: throw FilePickerException("Expected argument 'path'")
             impl.writeFileWithIdentifier(result, identifier, File(path))
           }
+          "disposeIdentifier" -> {
+            val identifier = call.argument<String>("identifier")
+              ?: throw FilePickerException("Expected argument 'identifier'")
+            impl.disposeIdentifier(identifier)
+            result.success(null)
+          }
           else -> {
             result.notImplemented()
           }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -266,6 +266,8 @@ class FileInfoDisplay extends StatelessWidget {
                   ),
                   IconButton(
                     onPressed: () async {
+                      await FilePickerWritable()
+                          .disposeIdentifier(fileInfo.identifier);
                       final appData = await appDataBloc.store.load();
                       await appDataBloc.store.save(appData.copyWith(
                           files: appData.files

--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -83,6 +83,9 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
                         throw FilePickerError.invalidArguments(message: "Expected 'identifier' and 'path' arguments.")
                 }
                 try writeFile(identifier: identifier, path: path, result: result)
+            case "disposeIdentifier":
+                // iOS doesn't have a concept of disposing identifiers (bookmarks)
+                result(nil)
             default:
                 result(FlutterMethodNotImplemented)
             }

--- a/lib/src/file_picker_writable.dart
+++ b/lib/src/file_picker_writable.dart
@@ -273,6 +273,18 @@ class FilePickerWritable {
     return _resultToFileInfo(result);
   }
 
+  /// Dispose of a persistable identifier, removing it from your app's list of
+  /// accessible files. Afterwards, you will need the user to re-pick the file
+  /// in order to access it again.
+  ///
+  /// Some platforms (Android) limit how many identifiers your app can persist
+  /// at once. Use this method to remove identifiers you no longer need.
+  Future<void> disposeIdentifier(String identifier) async {
+    _logger.finest('disposeIdentifier()');
+    return _channel
+        .invokeMethod<void>('disposeIdentifier', {'identifier': identifier});
+  }
+
   FileInfo _resultToFileInfo(Map<String, String> result) {
     return FileInfo(
       identifier: result['identifier']!,


### PR DESCRIPTION
On Android there is a limit to the number of persistable URIs an app is allowed to have at once.

Apparently in Android 11 you can have up to 512, but before that it was only 128 ([source](https://commonsware.com/blog/2020/06/13/count-your-saf-uri-permission-grants.html)).

It would be good to have a `dispose` method to allow removing unneeded URIs thus avoiding the limit.

I couldn't find any equivalent on iOS, so the implementation there is a noop.