### PR TITLE
Implement disposeAllIdentifiers

### DIFF
--- a/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritableImpl.kt
+++ b/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritableImpl.kt
@@ -321,6 +321,17 @@ class FilePickerWritableImpl(
     contentResolver.releasePersistableUriPermission(Uri.parse(identifier), takeFlags)
   }
 
+  fun disposeAllIdentifiers() {
+    val activity = requireActivity()
+    val contentResolver = activity.applicationContext.contentResolver
+    val takeFlags: Int = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+      Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+    for (permission in contentResolver.persistedUriPermissions) {
+      plugin.logDebug("Releasing identifier: $permission")
+      contentResolver.releasePersistableUriPermission(permission.uri, takeFlags)
+    }
+  }
+
   private fun requireActivity() = (plugin.activity
     ?: throw FilePickerException("Illegal state, expected activity to be there."))
 

--- a/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritablePlugin.kt
+++ b/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritablePlugin.kt
@@ -134,6 +134,10 @@ class FilePickerWritablePlugin : FlutterPlugin, MethodCallHandler,
             impl.disposeIdentifier(identifier)
             result.success(null)
           }
+          "disposeAllIdentifiers" -> {
+            impl.disposeAllIdentifiers()
+            result.success(null)
+          }
           else -> {
             result.notImplemented()
           }

--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -83,7 +83,7 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
                         throw FilePickerError.invalidArguments(message: "Expected 'identifier' and 'path' arguments.")
                 }
                 try writeFile(identifier: identifier, path: path, result: result)
-            case "disposeIdentifier":
+            case "disposeIdentifier", "disposeAllIdentifiers":
                 // iOS doesn't have a concept of disposing identifiers (bookmarks)
                 result(nil)
             default:

--- a/lib/src/file_picker_writable.dart
+++ b/lib/src/file_picker_writable.dart
@@ -285,6 +285,18 @@ class FilePickerWritable {
         .invokeMethod<void>('disposeIdentifier', {'identifier': identifier});
   }
 
+  /// Dispose of all identifiers persisted for your app. Afterwards, you will
+  /// need the user to re-pick any files in order to access them.
+  ///
+  /// Some platforms (Android) limit how many identifiers your app can persist
+  /// at once. Use this method to ensure that all identifiers are disposed, even
+  /// in the case where e.g. you have lost track of an identifier and so cannot
+  /// call [disposeIdentifier] on it.
+  Future<void> disposeAllIdentifiers() async {
+    _logger.finest('disposeAllIdentifiers()');
+    return _channel.invokeMethod<void>('disposeAllIdentifiers');
+  }
+
   FileInfo _resultToFileInfo(Map<String, String> result) {
     return FileInfo(
       identifier: result['identifier']!,


### PR DESCRIPTION
Per discussion here: https://github.com/hpoul/file_picker_writable/pull/19#issuecomment-819555749

Note that it looks like a persisted grant can be restored without opening a file picker *for the lifetime of the process that obtained the grant* even after you have disposed the grant.

After the process exits (the app is restarted) the grant is permanently gone until the user explicitly picks the file again.