### PR TITLE
Fix the writeFileWithIdentifier method for Android (correct mode for opening stream)

### DIFF
--- a/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritableImpl.kt
+++ b/android/src/main/kotlin/codeux/design/filepicker/file_picker_writable/FilePickerWritableImpl.kt
@@ -303,7 +303,7 @@ class FilePickerWritableImpl(
     val activity = requireActivity()
     val contentResolver = activity.contentResolver
     withContext(Dispatchers.IO) {
-      contentResolver.openOutputStream(fileUri, "w").use { output ->
+      contentResolver.openOutputStream(fileUri, "wt").use { output ->
         require(output != null)
         file.inputStream().use { input ->
           input.copyTo(output)


### PR DESCRIPTION
Needed for correct work in Android >= 10