### PR TITLE
Obtain iOS bookmark only after ensuring the file exists locally

### DIFF
--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -226,8 +226,9 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
         if !securityScope {
             logDebug("Warning: startAccessingSecurityScopedResource is false for \(url)")
         }
-        let bookmark = try url.bookmarkData()
         let tempFile = try _copyToTempDirectory(url: url)
+        // Get bookmark *after* ensuring file has been materialized to local device!
+        let bookmark = try url.bookmarkData()
         return _fileInfoResult(tempFile: tempFile, originalURL: url, bookmark: bookmark, persistable: persistable)
     }
     
@@ -270,8 +271,9 @@ extension SwiftFilePickerWritablePlugin : UIDocumentPickerDelegate {
 //                }
                 try _writeFile(path: path, destination: targetFile, skipDestinationStartAccess: true)
                 
-                let bookmark = try targetFile.bookmarkData()
                 let tempFile = try _copyToTempDirectory(url: targetFile)
+                // Get bookmark *after* ensuring file has been created!
+                let bookmark = try targetFile.bookmarkData()
                 _sendFilePickerResult(_fileInfoResult(tempFile: tempFile, originalURL: targetFile, bookmark: bookmark))
                 return
             }


### PR DESCRIPTION
The call to `URL.bookmarkData()` can fail with some file providers (such as [Tresorit](https://tresorit.com/) as reported [here](https://github.com/amake/orgro/issues/55#issuecomment-1049251625)) if the file is e.g. online only and not yet materialized to the local device.