### PR TITLE
📝 removed filename length restriction

### DIFF
--- a/lib/src/file_picker_writable.dart
+++ b/lib/src/file_picker_writable.dart
@@ -315,9 +315,6 @@ class FilePickerWritable {
 
   Future<T> _createFileInNewTempDirectory<T>(
       String baseName, Future<T> Function(File tempFile) callback) async {
-    if (baseName.length > 30) {
-      baseName = baseName.substring(0, 30);
-    }
     final tempDirBase = await getTemporaryDirectory();
 
     final tempDir = await tempDirBase.createTemp('file_picker_writable');


### PR DESCRIPTION
Hey @hpoul, I needed to create file names with length longer than 30. Hence made this change and raised this PR.

Also a solution to https://github.com/hpoul/file_picker_writable/issues/34.