### PR TITLE
Handle opening URLs from the OS with UIScene

### DIFF
--- a/ios/Classes/SwiftFilePickerWritablePlugin.swift
+++ b/ios/Classes/SwiftFilePickerWritablePlugin.swift
@@ -43,6 +43,7 @@ public class SwiftFilePickerWritablePlugin: NSObject, FlutterPlugin {
 
     registrar.addMethodCallDelegate(self, channel: channel)
     registrar.addApplicationDelegate(self)
+    registrar.addSceneDelegate(self)
 
     let eventChannel = FlutterEventChannel(name: "design.codeux.file_picker_writable/events", binaryMessenger: registrar.messenger())
     eventChannel.setStreamHandler(self)
@@ -324,7 +325,7 @@ extension SwiftFilePickerWritablePlugin: UIDocumentPickerDelegate {
 }
 
 // application delegate methods..
-extension SwiftFilePickerWritablePlugin: FlutterApplicationLifeCycleDelegate {
+extension SwiftFilePickerWritablePlugin: FlutterApplicationLifeCycleDelegate, FlutterSceneLifeCycleDelegate {
   public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     logDebug("Opening URL \(url) - options: \(options)")
     let persistable: Bool
@@ -356,6 +357,28 @@ extension SwiftFilePickerWritablePlugin: FlutterApplicationLifeCycleDelegate {
     logDebug("continue userActivity webpageURL: \(incomingURL)")
     // TODO: Confirm that persistable should be true here
     return _handle(url: incomingURL, persistable: true)
+  }
+
+  public func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions?) -> Bool {
+    logDebug("scene will connect with \(connectionOptions?.urlContexts.count ?? 0) URLContexts")
+    var handled = false
+    if let urlContexts = connectionOptions?.urlContexts {
+      for context in urlContexts {
+        logDebug("attempting to handle \(context.url)")
+        handled = _handle(url: context.url, persistable: context.options.openInPlace) || handled
+      }
+    }
+    return handled
+  }
+
+  public func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) -> Bool {
+    var handled = false
+    logDebug("openURLContexts for \(URLContexts.count) items")
+    for context in URLContexts {
+      logDebug("attempting to handle \(context.url)")
+      handled = _handle(url: context.url, persistable: context.options.openInPlace) || handled
+    }
+    return handled
   }
     
   private func _handle(url: URL, persistable: Bool) -> Bool {


### PR DESCRIPTION
This fixes the share-to-launch issue described in https://github.com/hpoul/file_picker_writable/issues/49#issuecomment-4378804810.

See https://docs.flutter.dev/release/breaking-changes/uiscenedelegate#migration-guide-for-flutter-plugins for details, but for apps that have opted into UIScene:

- [`scene:willConnectToSession:options:`](https://developer.apple.com/documentation/uikit/uiscenedelegate/3197914-scene) is called at app launch and contains any URLs meant to be opened. This is *required* because the old method ([`application:willFinishLaunchingWithOptions:`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623032-application)) is no longer called at all
- [`scene:openURLContexts:`](https://developer.apple.com/documentation/uikit/uiscenedelegate/3238059-scene) I think (based on experiment) is not strictly required because if it is missing then the event will go unhandled and will make its way to [`application:openURL:options:`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application) as a fallback. But it's better to explicitly use this method because a) the old method will be deprecated and removed eventually, and b) this method supports multiple URLs, various metadata, etc.

This PR doesn't attempt to make use of any newly available metadata. Also, in the [`scene:willConnectToSession:options:`](https://developer.apple.com/documentation/uikit/uiscenedelegate/3197914-scene) scenario all but the last URL is silently discarded.